### PR TITLE
Hotfix/#295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 이 프로젝트에서 주목할만한 모든 변경 사항이이 파일에 문서화됩니다.
 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/)의 형식을 기본으로 구성됩니다. 현재 버전은 [#181](https://github.com/Hansanghyeon/4log/issues/181)위와 같은 내용으로 구성됩니다.
 
+## [1.10.3] - 2020-08-09
+
+### Fixed
+
+- `html-react-parser` 패키지가 코드블럭의 string으로 표현되어야할 태그들까지 모두 html tag로 변경해주는 것을 `parser`를 사용할때 `options`에다가 원본 string값을 넘겨서 노출되지않던 부분까지 모두 보이게 수정
+
 ## [1.10.2] - 2020-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "4log",
-  "version": "1.10.1",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "4log",
-  "version": "1.10.1",
+  "version": "1.10.3",
   "description": "4log github page package",
   "main": "index.js",
   "scripts": {

--- a/src/views/components/templates/post/Wp/index.tsx
+++ b/src/views/components/templates/post/Wp/index.tsx
@@ -13,7 +13,7 @@ interface ContentReactMemoType {
   wpData: Array<string>;
 }
 const ContentMemo = React.memo(({ wpData }: ContentReactMemoType): any => {
-  return wpData.map((block: string) => parse(block, options));
+  return wpData.map((block: string) => parse(block, options(block)));
 });
 
 const WpPostLayout = ({ data }: any) => {

--- a/src/views/components/templates/post/Wp/options.tsx
+++ b/src/views/components/templates/post/Wp/options.tsx
@@ -8,11 +8,13 @@ import SeoPreviewCard from '#/SeoPreviewCard';
 import SyntaxHighlighter from '#/SyntaxHighlighter';
 
 // FIXME 리팩토링 할일 해당 코드를 더 간결하게 만들수있나 고민
-const options = {
-  replace: ({ name, children, attribs, parent }: any) => {
+const options = (block: string) => ({
+  replace: (domNode: any) => {
+    const { name, children, attribs, parent } = domNode;
+    const _block = block;
     if (!name) return;
     if (name === 'pre' && attribs.class === 'wp-block-code') {
-      return domToReact(children, options);
+      return domToReact(children, options(_block));
     }
     if (
       name === 'code' &&
@@ -28,7 +30,9 @@ const options = {
       };
       return (
         <SyntaxHighlighter {...SyntaxHighlighterProps}>
-          {domToReact(children)}
+          {block
+            .replace(/<pre.+>/, '')
+            .replace(/\n<\/code><\/pre>|<\/code><\/pre>/, '')}
         </SyntaxHighlighter>
       );
     }
@@ -53,7 +57,7 @@ const options = {
       return <DownloadButton>{domToReact(children)}</DownloadButton>;
     }
   },
-};
+});
 
 // HTML react parser options
 // const component: any = {


### PR DESCRIPTION
## [1.10.3] - 2020-08-09

### Fixed

- `html-react-parser` 패키지가 코드블럭의 string으로 표현되어야할 태그들까지 모두 html tag로 변경해주는 것을 `parser`를 사용할때 `options`에다가 원본 string값을 넘겨서 노출되지않던 부분까지 모두 보이게 수정